### PR TITLE
gh-122: handle modules that live in a major-version subdirectory

### DIFF
--- a/pkg/clients/zips/rewrite.go
+++ b/pkg/clients/zips/rewrite.go
@@ -4,11 +4,13 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
+	"io/ioutil"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
-
+	"github.com/modprox/mp/pkg/loggy"
 	"github.com/modprox/mp/pkg/coordinates"
 	"github.com/modprox/mp/pkg/repository"
 )
@@ -17,6 +19,8 @@ const (
 	goModFile     = "go.mod"
 	hgArchiveFile = ".hg_archival.txt"
 )
+
+var log = loggy.New("zips")
 
 // Rewrite the zip we downloaded from the upstream VCS into a zip file in the format
 // required by the go/cmd tooling. Fundamentally the zip file the Go tooling requires
@@ -27,11 +31,14 @@ const (
 // - limits the size of upstream LICENSE to 16 MiB
 // - limits the size of upstream go.mod file to 16MiB
 // -
-// - removes submodules
+// - removes other modules living in the same repo
 // -
 //
 // The only complete "documentation" for the format of the new zip archive is in
 // the go tool source code: go/src/cmd/go/internal/modfetch/coderepo.go
+//
+// The zip may contain multiple modules, each with its own go.mod.  We need to prune everything
+// that isn't in our module.
 func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error) {
 	in := bytes.NewReader(b)
 	unZip, err := zip.NewReader(in, int64(len(b)))
@@ -39,11 +46,25 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 		return nil, err
 	}
 
+	majorVersion, err := majorVersion(mod.Version)
+	if err != nil {
+		return nil, err
+	}
+
 	out := bytes.NewBuffer([]byte{})
 	reZip := zip.NewWriter(out)
 
+	// everything before the first / in the top-level entry of the zip file
 	topPrefix := ""
-	hasGoMod := make(map[string]bool) // path => has go.mod file
+
+	goModPath := make(map[string]string) // path => module specified in that directory's go.mod file, if that file exists
+
+	// whether there's a LICENSE file in the top-level directory
+	haveTopLicense := false
+
+	// contents of LICENSE in top-level directory, if that file exists
+	var topLicenseBytes []byte
+
 	for _, zf := range unZip.File {
 		if topPrefix == "" {
 			i := strings.Index(zf.Name, "/")
@@ -57,27 +78,47 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 		}
 		dir, file := path.Split(zf.Name)
 		if file == goModFile {
-			hasGoMod[dir] = true
+			rc, err := zf.Open()
+			if err != nil {
+				return nil, err
+			}
+			goModBytes, err := ioutil.ReadAll(rc)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error reading %s", zf.Name)
+			}
+			modulePath := ModulePath(goModBytes)
+			if modulePath == "" {
+				return nil, errors.Errorf("unable to extract module path from %s", zf.Name)
+			}
+			goModPath[dir] = modulePath
+		} else if file == "LICENSE" && dir == topPrefix {
+			rc, err := zf.Open()
+			if err != nil {
+				return nil, err
+			}
+			bytes, err := ioutil.ReadAll(rc)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error reading %s", zf.Name)
+			}
+			topLicenseBytes = bytes
+			haveTopLicense = true
 		}
+
 	}
 
-	root := topPrefix
-	inSubModule := func(name string) bool {
-		for {
-			dir, _ := path.Split(name)
-			if len(dir) <= len(root) {
-				return false
-			}
-
-			if hasGoMod[dir] {
-				return true
-			}
-
-			name = dir[:len(dir)-1]
-		}
+	// If the requested module is in a subdirectory of the repo, we'll need to strip that subdirectory
+	// name from each of the module's files.  Example: if the version is v2.0.4, strip the "v2/" prefix
+	// from each of module's filenames.
+	//
+	// versionPrefix is that prefix.
+	var versionPrefix string
+	if majorVersion != "" && strings.HasSuffix(mod.Source, majorVersion) {
+		versionPrefix = majorVersion + "/"
 	}
 
+	haveModLicense := false
 	for _, zf := range unZip.File {
+		// TODO: I think we already calculated topPrefix above, so we shouldn't need to do it here
 		if topPrefix == "" {
 			i := strings.Index(zf.Name, "/")
 			if i < 0 {
@@ -91,6 +132,7 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 			continue
 		}
 
+		// TODO: didn't we already check this earlier?
 		if !strings.HasPrefix(zf.Name, topPrefix) {
 			return nil, errors.Errorf("upstream zip file contains multiple top-level directories")
 		}
@@ -106,14 +148,20 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 			continue
 		}
 
-		if inSubModule(zf.Name) {
-			// no submodule directories
-			continue
+		if len(goModPath) > 0 {
+			if modPath := moduleOf(goModPath, zf.Name); modPath != mod.Source {
+				continue
+			}
 		}
 
+		// TODO: should do this in the earlier loop since it's searching for go.mod files
 		base := path.Base(name)
 		if strings.ToLower(base) == goModFile && base != goModFile {
 			return nil, errors.Errorf("upstream zip file contains %s, want all lower-case go.mod", zf.Name)
+		}
+
+		if name == "LICENSE" {
+			haveModLicense = true
 		}
 
 		rc, err := zf.Open()
@@ -121,12 +169,25 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 			return nil, err
 		}
 
-		w, err := reZip.Create(mod.Source + "@" + mod.Version + "/" + name) // source@version/path
+		unversionedName := strings.TrimPrefix(name, versionPrefix)
+
+		w, err := reZip.Create(mod.Source + "@" + mod.Version + "/" + unversionedName) // source@version/path
 		if err != nil {
 			return nil, err
 		}
 
 		if _, err := io.Copy(w, rc); err != nil {
+			return nil, err
+		}
+	}
+
+	// If the module doesn't have a LICENSE file but the top-level directory does, copy it to the module.
+	if !haveModLicense && haveTopLicense {
+		w, err := reZip.Create(mod.Source + "@" + mod.Version + "/LICENSE")
+		if err != nil {
+			return nil, err
+		}
+		if _, err := w.Write(topLicenseBytes); err != nil {
 			return nil, err
 		}
 	}
@@ -149,3 +210,89 @@ func isVendorPath(name string) bool {
 	}
 	return strings.Contains(name[i:], "/")
 }
+
+// Given a mapping from dir path to module path, determine the module path for the specified file.  It's going to be the
+// module for the longest dir path that prefixes this file's path.  You could probably use a clever data structure for this
+// but there aren't likely to be many modules, so why bother?  If none match, return an empty string.
+func moduleOf(goModPath map[string]string, filepath string) string {
+	var longestDirPath string
+	for dirpath := range goModPath {
+		if strings.HasPrefix(filepath, dirpath) {
+			if len(dirpath) > len(longestDirPath) {
+				longestDirPath = dirpath
+			}
+		}
+	}
+	if longestDirPath == "" {
+		return ""
+	}
+
+	return goModPath[longestDirPath]
+}
+
+func majorVersion(version string) (string, error) {
+	if version[0] != 'v' {
+		return "", errors.Errorf("version string does not begin with 'v': %s", version)
+	}
+
+	i := 1
+	for i < len(version) && version[i] != '.' {
+		i = i + 1
+	}
+	if i >= len(version) || version[i] != '.' {
+		return "", errors.Errorf("version string does not contain a dot: %s", version)
+	}
+
+	m := version[:i]
+	if m == "v0" || m == "v1" {
+		return "", nil
+	}
+
+	return m, nil
+}
+
+// Copied from cmd/go/internal/modfile/read.go
+var (
+	slashSlash = []byte("//")
+	moduleStr  = []byte("module")
+)
+
+// Copied from cmd/go/internal/modfile/read.go
+//
+// ModulePath returns the module path from the gomod file text.
+// If it cannot find a module path, it returns an empty string.
+// It is tolerant of unrelated problems in the go.mod file.
+func ModulePath(mod []byte) string {
+	for len(mod) > 0 {
+		line := mod
+		mod = nil
+		if i := bytes.IndexByte(line, '\n'); i >= 0 {
+			line, mod = line[:i], line[i+1:]
+		}
+		if i := bytes.Index(line, slashSlash); i >= 0 {
+			line = line[:i]
+		}
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, moduleStr) {
+			continue
+		}
+		line = line[len(moduleStr):]
+		n := len(line)
+		line = bytes.TrimSpace(line)
+		if len(line) == n || len(line) == 0 {
+			continue
+		}
+
+		if line[0] == '"' || line[0] == '`' {
+			p, err := strconv.Unquote(string(line))
+			if err != nil {
+				return "" // malformed quoted string or multiline module path
+			}
+			return p
+		}
+
+		return string(line)
+	}
+	return "" // missing module path
+}
+

--- a/pkg/clients/zips/rewrite.go
+++ b/pkg/clients/zips/rewrite.go
@@ -118,23 +118,9 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 
 	haveModLicense := false
 	for _, zf := range unZip.File {
-		// TODO: I think we already calculated topPrefix above, so we shouldn't need to do it here
-		if topPrefix == "" {
-			i := strings.Index(zf.Name, "/")
-			if i < 0 {
-				return nil, errors.Errorf("upstream missing top-level directory prefix")
-			}
-			topPrefix = zf.Name[:i+1]
-		}
-
 		if strings.HasSuffix(zf.Name, "/") {
 			// drop directory dummy entries
 			continue
-		}
-
-		// TODO: didn't we already check this earlier?
-		if !strings.HasPrefix(zf.Name, topPrefix) {
-			return nil, errors.Errorf("upstream zip file contains multiple top-level directories")
 		}
 
 		name := strings.TrimPrefix(zf.Name, topPrefix)
@@ -154,7 +140,6 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 			}
 		}
 
-		// TODO: should do this in the earlier loop since it's searching for go.mod files
 		base := path.Base(name)
 		if strings.ToLower(base) == goModFile && base != goModFile {
 			return nil, errors.Errorf("upstream zip file contains %s, want all lower-case go.mod", zf.Name)
@@ -170,7 +155,6 @@ func Rewrite(mod coordinates.Module, b repository.Blob) (repository.Blob, error)
 		}
 
 		unversionedName := strings.TrimPrefix(name, versionPrefix)
-
 		w, err := reZip.Create(mod.Source + "@" + mod.Version + "/" + unversionedName) // source@version/path
 		if err != nil {
 			return nil, err

--- a/pkg/clients/zips/rewrite_test.go
+++ b/pkg/clients/zips/rewrite_test.go
@@ -1,0 +1,77 @@
+package zips
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_majorVersion(t *testing.T) {
+	tryMajorVersion(t, "v2.0.4", "v2", false)
+	tryMajorVersion(t, "v1.0.0", "", false)
+	tryMajorVersion(t, "v0.0.1", "", false)
+	tryMajorVersion(t, "blah", "", true)
+	tryMajorVersion(t, "v123", "", true)
+}
+
+func tryMajorVersion(t *testing.T, version, expectedMajor string, expectError bool) {
+	m, err := majorVersion(version)
+	if expectError {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+		require.Equal(t, expectedMajor, m)
+	}
+}
+
+func Test_ModulePath(t *testing.T) {
+	gomod := `module github.com/modprox/mp
+
+require (
+	github.com/googleapis/gax-go/v2 v2.0.4
+	google.golang.org/grpc 1.19.0
+)
+`
+	expected := "github.com/modprox/mp"
+
+	s := ModulePath([]byte(gomod))
+
+	require.Equal(t, expected, s)
+}
+
+func Test_ModulePath_none(t *testing.T) {
+	gomod := `// I absent-mindedly commented out the module line
+//module github.com/modprox/mp`
+
+	s := ModulePath([]byte(gomod))
+	require.Equal(t, "", s)
+}
+
+func Test_moduleOf(t *testing.T) {
+	goModPath := map[string]string{
+		"github.com/billsmith/module1-1.1.4": "github.com/billsmith/module1",
+		"github.com/billsmith/module1/v2": "github.com/billsmith/module1/v2",
+		"github.com/billsmith/module1/v3": "github.com/billsmith/module1/v3",
+	}
+
+	require.Equal(t, "github.com/billsmith/module1", moduleOf(goModPath, "github.com/billsmith/module1-1.1.4/main.go"))
+}
+
+func Test_moduleOf_v2(t *testing.T) {
+	goModPath := map[string]string{
+		"github.com/billsmith/module1-2.0.9": "github.com/billsmith/module1",
+		"github.com/billsmith/module1-2.0.9/v2": "github.com/billsmith/module1/v2",
+		"github.com/billsmith/module1-2.0.9/v3": "github.com/billsmith/module1/v3",
+	}
+
+	require.Equal(t, "github.com/billsmith/module1/v2", moduleOf(goModPath, "github.com/billsmith/module1-2.0.9/v2/main.go"))
+}
+
+func Test_moduleOf_v4(t *testing.T) {
+	goModPath := map[string]string{
+		"github.com/billsmith/module1/v2": "github.com/billsmith/module1/v2",
+		"github.com/billsmith/module1/v3": "github.com/billsmith/module1/v3",
+	}
+
+	require.Equal(t, "", moduleOf(goModPath, "github.com/billsmith/module1/v4/main.go"))
+}

--- a/pkg/repository/blob.go
+++ b/pkg/repository/blob.go
@@ -10,9 +10,9 @@ import (
 )
 
 // A Blob is an in-memory zip archive, representative of
-// a repository that was downloaded from upstream.
+// a module that was extracted from a repository that was downloaded from upstream.
 //
-// There might not be a go.mod file.
+// There might not be a go.mod file, but there should not be more than one.
 type Blob []byte
 
 func (b Blob) ModFile() (string, bool, error) {
@@ -23,9 +23,6 @@ func (b Blob) ModFile() (string, bool, error) {
 	}
 
 	for _, f := range unzip.File {
-
-		// todo: BUG - there could be more than 1 go.mod file, must choose
-		// todo: the correct one (hmmm, what if they want a nested module?)
 		filename := filepath.Base(f.Name)
 		if filename == "go.mod" {
 			rc, err := f.Open()

--- a/pkg/upstream/go-get.go
+++ b/pkg/upstream/go-get.go
@@ -3,6 +3,7 @@ package upstream
 import (
 	"bufio"
 	"fmt"
+	"github.com/modprox/mp/pkg/loggy"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -51,6 +52,7 @@ func (t *GoGetTransform) doGoGetRequest(r *Request) (goGetMeta, error) {
 
 var (
 	sourceRe = regexp.MustCompile(`(http[s]?)://([\w-.]+)/([\w-./]+)`)
+	log = loggy.New("go-get")
 )
 
 // gives us transport, domain, path
@@ -58,12 +60,14 @@ func parseGoGetMetadata(content string) (goGetMeta, error) {
 	if ggm, exists, err := tryParseGoMetaTag("go-source", content); err != nil {
 		return ggm, err
 	} else if exists {
+		log.Infof("found go-source tag: %#v", ggm)
 		return ggm, nil
 	}
 
 	if ggm, exists, err := tryParseGoMetaTag("go-import", content); err != nil {
 		return ggm, err
 	} else if exists {
+		log.Infof("found go-import tag %#v", ggm)
 		return ggm, nil
 	}
 

--- a/proxy/internal/modules/store/fs.go
+++ b/proxy/internal/modules/store/fs.go
@@ -96,7 +96,7 @@ func (s *fsStore) removeZip(mod coordinates.Module) error {
 }
 
 func (s *fsStore) PutZip(mod coordinates.Module, blob repository.Blob) error {
-	s.log.Infof("will save %s do disk, %d bytes", mod, len(blob))
+	s.log.Infof("will save %s to disk, %d bytes", mod, len(blob))
 
 	start := time.Now()
 	if err := s.putZip(mod, blob); err != nil {


### PR DESCRIPTION
This pull request allows the proxy to work with modules that live in a major-version subdirectory, e.g. github.com/gax-go/v2 v2.0.4.  There were no changes to the registry.

