### PR TITLE
issue #136: add  /history endpoint

### DIFF
--- a/pkg/clients/registry/client_mock.go
+++ b/pkg/clients/registry/client_mock.go
@@ -203,7 +203,11 @@ func (m *ClientMock) MinimockGetInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.GetMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterGetCounter) < 1 {
-		m.t.Errorf("Expected call to ClientMock.Get with params: %#v", *m.GetMock.defaultExpectation.params)
+		if m.GetMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ClientMock.Get")
+		} else {
+			m.t.Errorf("Expected call to ClientMock.Get with params: %#v", *m.GetMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcGet != nil && mm_atomic.LoadUint64(&m.afterGetCounter) < 1 {
@@ -378,7 +382,11 @@ func (m *ClientMock) MinimockPostInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.PostMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterPostCounter) < 1 {
-		m.t.Errorf("Expected call to ClientMock.Post with params: %#v", *m.PostMock.defaultExpectation.params)
+		if m.PostMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ClientMock.Post")
+		} else {
+			m.t.Errorf("Expected call to ClientMock.Post with params: %#v", *m.PostMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcPost != nil && mm_atomic.LoadUint64(&m.afterPostCounter) < 1 {

--- a/pkg/clients/zips/client_mock.go
+++ b/pkg/clients/zips/client_mock.go
@@ -204,7 +204,11 @@ func (m *ClientMock) MinimockGetInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.GetMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterGetCounter) < 1 {
-		m.t.Errorf("Expected call to ClientMock.Get with params: %#v", *m.GetMock.defaultExpectation.params)
+		if m.GetMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ClientMock.Get")
+		} else {
+			m.t.Errorf("Expected call to ClientMock.Get with params: %#v", *m.GetMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcGet != nil && mm_atomic.LoadUint64(&m.afterGetCounter) < 1 {

--- a/pkg/history/hist.go
+++ b/pkg/history/hist.go
@@ -1,0 +1,3 @@
+package history
+
+//go:generate petrify -pkg history -o generated.go .

--- a/pkg/history/history.txt
+++ b/pkg/history/history.txt
@@ -1,0 +1,14 @@
+Change history
+==============
+
+Version 0.1.2
+-------------
+
+https://github.com/modprox/mp/issues/136: Add /history endpoint
+
+
+Version 0.1.1
+-------------
+
+https://github.com/modprox/mp/issues/122: proxy does not handle modules using v2 directory convention
+

--- a/pkg/metrics/stats/sender_mock.go
+++ b/pkg/metrics/stats/sender_mock.go
@@ -181,7 +181,11 @@ func (m *SenderMock) MinimockCountInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.CountMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterCountCounter) < 1 {
-		m.t.Errorf("Expected call to SenderMock.Count with params: %#v", *m.CountMock.defaultExpectation.params)
+		if m.CountMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to SenderMock.Count")
+		} else {
+			m.t.Errorf("Expected call to SenderMock.Count with params: %#v", *m.CountMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcCount != nil && mm_atomic.LoadUint64(&m.afterCountCounter) < 1 {
@@ -327,7 +331,11 @@ func (m *SenderMock) MinimockGaugeInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.GaugeMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterGaugeCounter) < 1 {
-		m.t.Errorf("Expected call to SenderMock.Gauge with params: %#v", *m.GaugeMock.defaultExpectation.params)
+		if m.GaugeMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to SenderMock.Gauge")
+		} else {
+			m.t.Errorf("Expected call to SenderMock.Gauge with params: %#v", *m.GaugeMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcGauge != nil && mm_atomic.LoadUint64(&m.afterGaugeCounter) < 1 {
@@ -473,7 +481,11 @@ func (m *SenderMock) MinimockGaugeMSInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.GaugeMSMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterGaugeMSCounter) < 1 {
-		m.t.Errorf("Expected call to SenderMock.GaugeMS with params: %#v", *m.GaugeMSMock.defaultExpectation.params)
+		if m.GaugeMSMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to SenderMock.GaugeMS")
+		} else {
+			m.t.Errorf("Expected call to SenderMock.GaugeMS with params: %#v", *m.GaugeMSMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcGaugeMS != nil && mm_atomic.LoadUint64(&m.afterGaugeMSCounter) < 1 {

--- a/pkg/upstream/resolver_mock.go
+++ b/pkg/upstream/resolver_mock.go
@@ -197,7 +197,11 @@ func (m *ResolverMock) MinimockResolveInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.ResolveMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterResolveCounter) < 1 {
-		m.t.Errorf("Expected call to ResolverMock.Resolve with params: %#v", *m.ResolveMock.defaultExpectation.params)
+		if m.ResolveMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ResolverMock.Resolve")
+		} else {
+			m.t.Errorf("Expected call to ResolverMock.Resolve with params: %#v", *m.ResolveMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcResolve != nil && mm_atomic.LoadUint64(&m.afterResolveCounter) < 1 {

--- a/proxy/internal/modules/get/downloader_mock.go
+++ b/proxy/internal/modules/get/downloader_mock.go
@@ -196,7 +196,11 @@ func (m *DownloaderMock) MinimockDownloadInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.DownloadMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterDownloadCounter) < 1 {
-		m.t.Errorf("Expected call to DownloaderMock.Download with params: %#v", *m.DownloadMock.defaultExpectation.params)
+		if m.DownloadMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to DownloaderMock.Download")
+		} else {
+			m.t.Errorf("Expected call to DownloaderMock.Download with params: %#v", *m.DownloadMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcDownload != nil && mm_atomic.LoadUint64(&m.afterDownloadCounter) < 1 {

--- a/proxy/internal/modules/store/index_mock.go
+++ b/proxy/internal/modules/store/index_mock.go
@@ -247,7 +247,11 @@ func (m *IndexMock) MinimockContainsInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.ContainsMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterContainsCounter) < 1 {
-		m.t.Errorf("Expected call to IndexMock.Contains with params: %#v", *m.ContainsMock.defaultExpectation.params)
+		if m.ContainsMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to IndexMock.Contains")
+		} else {
+			m.t.Errorf("Expected call to IndexMock.Contains with params: %#v", *m.ContainsMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcContains != nil && mm_atomic.LoadUint64(&m.afterContainsCounter) < 1 {
@@ -550,7 +554,11 @@ func (m *IndexMock) MinimockInfoInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.InfoMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterInfoCounter) < 1 {
-		m.t.Errorf("Expected call to IndexMock.Info with params: %#v", *m.InfoMock.defaultExpectation.params)
+		if m.InfoMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to IndexMock.Info")
+		} else {
+			m.t.Errorf("Expected call to IndexMock.Info with params: %#v", *m.InfoMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcInfo != nil && mm_atomic.LoadUint64(&m.afterInfoCounter) < 1 {
@@ -724,7 +732,11 @@ func (m *IndexMock) MinimockModInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.ModMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterModCounter) < 1 {
-		m.t.Errorf("Expected call to IndexMock.Mod with params: %#v", *m.ModMock.defaultExpectation.params)
+		if m.ModMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to IndexMock.Mod")
+		} else {
+			m.t.Errorf("Expected call to IndexMock.Mod with params: %#v", *m.ModMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcMod != nil && mm_atomic.LoadUint64(&m.afterModCounter) < 1 {
@@ -897,7 +909,11 @@ func (m *IndexMock) MinimockPutInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.PutMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterPutCounter) < 1 {
-		m.t.Errorf("Expected call to IndexMock.Put with params: %#v", *m.PutMock.defaultExpectation.params)
+		if m.PutMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to IndexMock.Put")
+		} else {
+			m.t.Errorf("Expected call to IndexMock.Put with params: %#v", *m.PutMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcPut != nil && mm_atomic.LoadUint64(&m.afterPutCounter) < 1 {
@@ -1070,7 +1086,11 @@ func (m *IndexMock) MinimockRemoveInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.RemoveMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterRemoveCounter) < 1 {
-		m.t.Errorf("Expected call to IndexMock.Remove with params: %#v", *m.RemoveMock.defaultExpectation.params)
+		if m.RemoveMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to IndexMock.Remove")
+		} else {
+			m.t.Errorf("Expected call to IndexMock.Remove with params: %#v", *m.RemoveMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcRemove != nil && mm_atomic.LoadUint64(&m.afterRemoveCounter) < 1 {
@@ -1373,7 +1393,11 @@ func (m *IndexMock) MinimockUpdateIDInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.UpdateIDMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterUpdateIDCounter) < 1 {
-		m.t.Errorf("Expected call to IndexMock.UpdateID with params: %#v", *m.UpdateIDMock.defaultExpectation.params)
+		if m.UpdateIDMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to IndexMock.UpdateID")
+		} else {
+			m.t.Errorf("Expected call to IndexMock.UpdateID with params: %#v", *m.UpdateIDMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcUpdateID != nil && mm_atomic.LoadUint64(&m.afterUpdateIDCounter) < 1 {
@@ -1547,7 +1571,11 @@ func (m *IndexMock) MinimockVersionsInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.VersionsMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterVersionsCounter) < 1 {
-		m.t.Errorf("Expected call to IndexMock.Versions with params: %#v", *m.VersionsMock.defaultExpectation.params)
+		if m.VersionsMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to IndexMock.Versions")
+		} else {
+			m.t.Errorf("Expected call to IndexMock.Versions with params: %#v", *m.VersionsMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcVersions != nil && mm_atomic.LoadUint64(&m.afterVersionsCounter) < 1 {

--- a/proxy/internal/modules/store/zip_store_mock.go
+++ b/proxy/internal/modules/store/zip_store_mock.go
@@ -209,7 +209,11 @@ func (m *ZipStoreMock) MinimockDelZipInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.DelZipMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterDelZipCounter) < 1 {
-		m.t.Errorf("Expected call to ZipStoreMock.DelZip with params: %#v", *m.DelZipMock.defaultExpectation.params)
+		if m.DelZipMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ZipStoreMock.DelZip")
+		} else {
+			m.t.Errorf("Expected call to ZipStoreMock.DelZip with params: %#v", *m.DelZipMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcDelZip != nil && mm_atomic.LoadUint64(&m.afterDelZipCounter) < 1 {
@@ -383,7 +387,11 @@ func (m *ZipStoreMock) MinimockGetZipInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.GetZipMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterGetZipCounter) < 1 {
-		m.t.Errorf("Expected call to ZipStoreMock.GetZip with params: %#v", *m.GetZipMock.defaultExpectation.params)
+		if m.GetZipMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ZipStoreMock.GetZip")
+		} else {
+			m.t.Errorf("Expected call to ZipStoreMock.GetZip with params: %#v", *m.GetZipMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcGetZip != nil && mm_atomic.LoadUint64(&m.afterGetZipCounter) < 1 {
@@ -557,7 +565,11 @@ func (m *ZipStoreMock) MinimockPutZipInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.PutZipMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterPutZipCounter) < 1 {
-		m.t.Errorf("Expected call to ZipStoreMock.PutZip with params: %#v", *m.PutZipMock.defaultExpectation.params)
+		if m.PutZipMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ZipStoreMock.PutZip")
+		} else {
+			m.t.Errorf("Expected call to ZipStoreMock.PutZip with params: %#v", *m.PutZipMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcPutZip != nil && mm_atomic.LoadUint64(&m.afterPutZipCounter) < 1 {

--- a/proxy/internal/problems/tracker_mock.go
+++ b/proxy/internal/problems/tracker_mock.go
@@ -209,7 +209,11 @@ func (m *TrackerMock) MinimockProblemInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.ProblemMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterProblemCounter) < 1 {
-		m.t.Errorf("Expected call to TrackerMock.Problem with params: %#v", *m.ProblemMock.defaultExpectation.params)
+		if m.ProblemMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to TrackerMock.Problem")
+		} else {
+			m.t.Errorf("Expected call to TrackerMock.Problem with params: %#v", *m.ProblemMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcProblem != nil && mm_atomic.LoadUint64(&m.afterProblemCounter) < 1 {
@@ -482,7 +486,11 @@ func (m *TrackerMock) MinimockSetInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.SetMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterSetCounter) < 1 {
-		m.t.Errorf("Expected call to TrackerMock.Set with params: %#v", *m.SetMock.defaultExpectation.params)
+		if m.SetMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to TrackerMock.Set")
+		} else {
+			m.t.Errorf("Expected call to TrackerMock.Set with params: %#v", *m.SetMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcSet != nil && mm_atomic.LoadUint64(&m.afterSetCounter) < 1 {

--- a/proxy/internal/service/init.go
+++ b/proxy/internal/service/init.go
@@ -5,17 +5,17 @@ import (
 	"os"
 	"time"
 
-	"oss.indeed.com/go/modprox/proxy/internal/modules/bg"
-
 	"github.com/pkg/errors"
 
 	"oss.indeed.com/go/modprox/pkg/clients/payloads"
 	"oss.indeed.com/go/modprox/pkg/clients/registry"
 	"oss.indeed.com/go/modprox/pkg/clients/zips"
+	"oss.indeed.com/go/modprox/pkg/history"
 	"oss.indeed.com/go/modprox/pkg/metrics/stats"
 	"oss.indeed.com/go/modprox/pkg/netservice"
 	"oss.indeed.com/go/modprox/pkg/upstream"
 	"oss.indeed.com/go/modprox/pkg/webutil"
+	"oss.indeed.com/go/modprox/proxy/internal/modules/bg"
 	"oss.indeed.com/go/modprox/proxy/internal/modules/get"
 	"oss.indeed.com/go/modprox/proxy/internal/modules/store"
 	"oss.indeed.com/go/modprox/proxy/internal/problems"
@@ -258,6 +258,7 @@ func initWebServer(p *Proxy) error {
 		p.store,
 		p.emitter,
 		p.dlTracker,
+		p.history,
 	)
 
 	server, err := p.config.APIServer.Server(mux)
@@ -280,5 +281,15 @@ func initWebServer(p *Proxy) error {
 		os.Exit(1)
 	}(mux)
 
+	return nil
+}
+
+func initHistory(p *Proxy) error {
+	historyBytes, err := history.Asset("history.txt")
+	if err != nil {
+		return err
+	}
+
+	p.history = string(historyBytes)
 	return nil
 }

--- a/proxy/internal/service/proxy.go
+++ b/proxy/internal/service/proxy.go
@@ -28,6 +28,7 @@ type Proxy struct {
 	bgWorker       bg.Worker
 	dlTracker      problems.Tracker
 	log            loggy.Logger
+	history        string
 }
 
 func NewProxy(configuration config.Configuration) *Proxy {
@@ -46,6 +47,7 @@ func NewProxy(configuration config.Configuration) *Proxy {
 		initBGWorker,
 		initHeartbeatSender,
 		initStartupConfigSender,
+		initHistory,
 		initWebServer,
 	} {
 		if err := f(p); err != nil {

--- a/proxy/internal/web/history.go
+++ b/proxy/internal/web/history.go
@@ -1,0 +1,30 @@
+package web
+
+import (
+	"net/http"
+
+	"oss.indeed.com/go/modprox/pkg/loggy"
+	"oss.indeed.com/go/modprox/pkg/metrics/stats"
+	"oss.indeed.com/go/modprox/proxy/internal/web/output"
+)
+
+type applicationHistory struct {
+	log     loggy.Logger
+	history string
+	emitter stats.Sender
+}
+
+func appHistory(emitter stats.Sender, history string) http.Handler {
+	return &applicationHistory{
+		emitter: emitter,
+		history: history,
+		log:     loggy.New("app-history"),
+	}
+}
+
+// e.g. GET http://localhost:9000/history
+
+func (h *applicationHistory) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	output.Write(w, output.Text, h.history)
+	h.emitter.Count("app-history-ok", 1)
+}

--- a/proxy/internal/web/router.go
+++ b/proxy/internal/web/router.go
@@ -26,6 +26,7 @@ func NewRouter(
 	store store.ZipStore,
 	emitter stats.Sender,
 	dlProblems problems.Tracker,
+	history string,
 ) http.Handler {
 
 	router := mux.NewRouter()
@@ -40,6 +41,9 @@ func NewRouter(
 	router.PathPrefix("/").Handler(modFile(index, emitter)).MatcherFunc(suffix(".mod")).Methods(get)
 	router.PathPrefix("/").Handler(modZip(store, emitter)).MatcherFunc(suffix(".zip")).Methods(get)
 	router.PathPrefix("/").Handler(modRM(index, store, emitter)).MatcherFunc(suffix(".rm")).Methods(post)
+
+	// metadata about this app
+	router.PathPrefix("/history").Handler(appHistory(emitter, history)).Methods(get)
 
 	// api operations
 	//

--- a/registry/internal/data/store_mock.go
+++ b/registry/internal/data/store_mock.go
@@ -258,7 +258,11 @@ func (m *StoreMock) MinimockDeleteModuleByIDInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.DeleteModuleByIDMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterDeleteModuleByIDCounter) < 1 {
-		m.t.Errorf("Expected call to StoreMock.DeleteModuleByID with params: %#v", *m.DeleteModuleByIDMock.defaultExpectation.params)
+		if m.DeleteModuleByIDMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to StoreMock.DeleteModuleByID")
+		} else {
+			m.t.Errorf("Expected call to StoreMock.DeleteModuleByID with params: %#v", *m.DeleteModuleByIDMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcDeleteModuleByID != nil && mm_atomic.LoadUint64(&m.afterDeleteModuleByIDCounter) < 1 {
@@ -432,7 +436,11 @@ func (m *StoreMock) MinimockInsertModulesInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.InsertModulesMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterInsertModulesCounter) < 1 {
-		m.t.Errorf("Expected call to StoreMock.InsertModules with params: %#v", *m.InsertModulesMock.defaultExpectation.params)
+		if m.InsertModulesMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to StoreMock.InsertModules")
+		} else {
+			m.t.Errorf("Expected call to StoreMock.InsertModules with params: %#v", *m.InsertModulesMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcInsertModules != nil && mm_atomic.LoadUint64(&m.afterInsertModulesCounter) < 1 {
@@ -993,7 +1001,11 @@ func (m *StoreMock) MinimockListModulesByIDsInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.ListModulesByIDsMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterListModulesByIDsCounter) < 1 {
-		m.t.Errorf("Expected call to StoreMock.ListModulesByIDs with params: %#v", *m.ListModulesByIDsMock.defaultExpectation.params)
+		if m.ListModulesByIDsMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to StoreMock.ListModulesByIDs")
+		} else {
+			m.t.Errorf("Expected call to StoreMock.ListModulesByIDs with params: %#v", *m.ListModulesByIDsMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcListModulesByIDs != nil && mm_atomic.LoadUint64(&m.afterListModulesByIDsCounter) < 1 {
@@ -1167,7 +1179,11 @@ func (m *StoreMock) MinimockListModulesBySourceInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.ListModulesBySourceMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterListModulesBySourceCounter) < 1 {
-		m.t.Errorf("Expected call to StoreMock.ListModulesBySource with params: %#v", *m.ListModulesBySourceMock.defaultExpectation.params)
+		if m.ListModulesBySourceMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to StoreMock.ListModulesBySource")
+		} else {
+			m.t.Errorf("Expected call to StoreMock.ListModulesBySource with params: %#v", *m.ListModulesBySourceMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcListModulesBySource != nil && mm_atomic.LoadUint64(&m.afterListModulesBySourceCounter) < 1 {
@@ -1469,7 +1485,11 @@ func (m *StoreMock) MinimockPurgeProxyInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.PurgeProxyMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterPurgeProxyCounter) < 1 {
-		m.t.Errorf("Expected call to StoreMock.PurgeProxy with params: %#v", *m.PurgeProxyMock.defaultExpectation.params)
+		if m.PurgeProxyMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to StoreMock.PurgeProxy")
+		} else {
+			m.t.Errorf("Expected call to StoreMock.PurgeProxy with params: %#v", *m.PurgeProxyMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcPurgeProxy != nil && mm_atomic.LoadUint64(&m.afterPurgeProxyCounter) < 1 {
@@ -1642,7 +1662,11 @@ func (m *StoreMock) MinimockSetHeartbeatInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.SetHeartbeatMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterSetHeartbeatCounter) < 1 {
-		m.t.Errorf("Expected call to StoreMock.SetHeartbeat with params: %#v", *m.SetHeartbeatMock.defaultExpectation.params)
+		if m.SetHeartbeatMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to StoreMock.SetHeartbeat")
+		} else {
+			m.t.Errorf("Expected call to StoreMock.SetHeartbeat with params: %#v", *m.SetHeartbeatMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcSetHeartbeat != nil && mm_atomic.LoadUint64(&m.afterSetHeartbeatCounter) < 1 {
@@ -1815,7 +1839,11 @@ func (m *StoreMock) MinimockSetStartConfigInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.SetStartConfigMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterSetStartConfigCounter) < 1 {
-		m.t.Errorf("Expected call to StoreMock.SetStartConfig with params: %#v", *m.SetStartConfigMock.defaultExpectation.params)
+		if m.SetStartConfigMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to StoreMock.SetStartConfig")
+		} else {
+			m.t.Errorf("Expected call to StoreMock.SetStartConfig with params: %#v", *m.SetStartConfigMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcSetStartConfig != nil && mm_atomic.LoadUint64(&m.afterSetStartConfigCounter) < 1 {

--- a/registry/internal/proxies/pruner_mock.go
+++ b/registry/internal/proxies/pruner_mock.go
@@ -196,7 +196,11 @@ func (m *PrunerMock) MinimockPruneInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.PruneMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterPruneCounter) < 1 {
-		m.t.Errorf("Expected call to PrunerMock.Prune with params: %#v", *m.PruneMock.defaultExpectation.params)
+		if m.PruneMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to PrunerMock.Prune")
+		} else {
+			m.t.Errorf("Expected call to PrunerMock.Prune with params: %#v", *m.PruneMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcPrune != nil && mm_atomic.LoadUint64(&m.afterPruneCounter) < 1 {

--- a/registry/internal/service/init.go
+++ b/registry/internal/service/init.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"time"
 
-	"oss.indeed.com/go/modprox/pkg/metrics/stats"
-
 	"github.com/gorilla/csrf"
 	"github.com/pkg/errors"
 	"github.com/shoenig/toolkit"
 
+	"oss.indeed.com/go/modprox/pkg/history"
+	"oss.indeed.com/go/modprox/pkg/metrics/stats"
 	"oss.indeed.com/go/modprox/pkg/webutil"
 	"oss.indeed.com/go/modprox/registry/internal/data"
 	"oss.indeed.com/go/modprox/registry/internal/proxies"
@@ -85,6 +85,7 @@ func initWebServer(r *Registry) error {
 		middleUI,
 		r.store,
 		r.emitter,
+		r.history,
 	)
 
 	server, err := r.config.WebServer.Server(mux)
@@ -108,5 +109,15 @@ func initWebServer(r *Registry) error {
 		os.Exit(1)
 	}(mux)
 
+	return nil
+}
+
+func initHistory(r *Registry) error {
+	historyBytes, err := history.Asset("history.txt")
+	if err != nil {
+		return err
+	}
+
+	r.history = string(historyBytes)
 	return nil
 }

--- a/registry/internal/service/registry.go
+++ b/registry/internal/service/registry.go
@@ -14,6 +14,7 @@ type Registry struct {
 	store   data.Store
 	emitter stats.Sender
 	log     loggy.Logger
+	history string
 }
 
 func NewRegistry(config config.Configuration) *Registry {
@@ -26,6 +27,7 @@ func NewRegistry(config config.Configuration) *Registry {
 		initSender,
 		initStore,
 		initProxyPrune,
+		initHistory,
 		initWebServer,
 	} {
 		if err := f(r); err != nil {

--- a/registry/internal/tools/finder/finder_mock.go
+++ b/registry/internal/tools/finder/finder_mock.go
@@ -196,7 +196,11 @@ func (m *FinderMock) MinimockFindInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.FindMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterFindCounter) < 1 {
-		m.t.Errorf("Expected call to FinderMock.Find with params: %#v", *m.FindMock.defaultExpectation.params)
+		if m.FindMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to FinderMock.Find")
+		} else {
+			m.t.Errorf("Expected call to FinderMock.Find with params: %#v", *m.FindMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcFind != nil && mm_atomic.LoadUint64(&m.afterFindCounter) < 1 {

--- a/registry/internal/tools/finder/versions_mock.go
+++ b/registry/internal/tools/finder/versions_mock.go
@@ -196,7 +196,11 @@ func (m *VersionsMock) MinimockRequestInspect() {
 
 	// if default expectation was set then invocations count should be greater than zero
 	if m.RequestMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterRequestCounter) < 1 {
-		m.t.Errorf("Expected call to VersionsMock.Request with params: %#v", *m.RequestMock.defaultExpectation.params)
+		if m.RequestMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to VersionsMock.Request")
+		} else {
+			m.t.Errorf("Expected call to VersionsMock.Request with params: %#v", *m.RequestMock.defaultExpectation.params)
+		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcRequest != nil && mm_atomic.LoadUint64(&m.afterRequestCounter) < 1 {

--- a/registry/internal/web/history.go
+++ b/registry/internal/web/history.go
@@ -1,0 +1,29 @@
+package web
+
+import (
+	"net/http"
+
+	"oss.indeed.com/go/modprox/pkg/loggy"
+	"oss.indeed.com/go/modprox/pkg/metrics/stats"
+)
+
+type historyHandler struct {
+	emitter stats.Sender
+	log     loggy.Logger
+	history string
+}
+
+func newHistoryHandler(emitter stats.Sender, history string) http.Handler {
+	return &historyHandler{
+		emitter: emitter,
+		log:     loggy.New("history-handler"),
+		history: history,
+	}
+}
+
+func (h *historyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte(h.history))
+
+	h.emitter.Count("ui-history-ok", 1)
+}

--- a/registry/internal/web/history_test.go
+++ b/registry/internal/web/history_test.go
@@ -1,0 +1,27 @@
+package web
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_history_ok(t *testing.T) {
+	h, mocks := makeRouter(t)
+	defer mocks.assertions()
+
+	request, err := http.NewRequest(http.MethodGet, "/history", nil)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	bytes, err := ioutil.ReadAll(recorder.Result().Body)
+	require.NoError(t, err)
+	require.Equal(t, "this is some fake history", string(bytes))
+}

--- a/registry/internal/web/router_test.go
+++ b/registry/internal/web/router_test.go
@@ -29,6 +29,6 @@ func makeRouter(t *testing.T) (http.Handler, mocks) {
 
 	mocks := newMocks(t)
 
-	router := NewRouter(nil, nil, mocks.store, emitter)
+	router := NewRouter(nil, nil, mocks.store, emitter, "this is some fake history")
 	return router, mocks
 }


### PR DESCRIPTION
Issue #136: add a /history endpoint to the registry and the proxy.  Neither require special headers or authentication.  Both return plaintext.  

Most of the changes are new things added  by minimock.