### PR TITLE
issue #137: fix .rm suffix

### DIFF
--- a/pkg/history/history.txt
+++ b/pkg/history/history.txt
@@ -5,6 +5,7 @@ Version 0.1.2
 -------------
 
 https://github.com/modprox/mp/issues/136: Add /history endpoint
+https://github.com/modprox/mp/issues/137: fix .rm suffix
 
 
 Version 0.1.1

--- a/pkg/repository/parse.go
+++ b/pkg/repository/parse.go
@@ -30,6 +30,7 @@ func Parse(s string) (coordinates.Module, error) {
 	s = strings.TrimSuffix(s, ".info")
 	s = strings.TrimSuffix(s, ".zip")
 	s = strings.TrimSuffix(s, ".mod")
+	s = strings.TrimSuffix(s, ".rm")
 	s = strings.Replace(s, "/@v/", " ", -1) // in web handlers
 	s = strings.Replace(s, "@v", " v", -1)  // pasted from logs
 

--- a/pkg/repository/parse_test.go
+++ b/pkg/repository/parse_test.go
@@ -34,6 +34,11 @@ func Test_Parse(t *testing.T) {
 		Source:  "github.com/cpuguy83/go-md2man",
 		Version: "v1.0.6",
 	}, false)
+
+	try("/github.com/cpuguy83/go-md2man/@v/v1.0.6.rm", coordinates.Module{
+		Source:  "github.com/cpuguy83/go-md2man",
+		Version: "v1.0.6",
+	}, false)
 }
 
 // http://localhost:9000/gopkg.in/check.v1/@v/v0.0.0-20161208181325-20d25e280405.info


### PR DESCRIPTION
.rm suffix was broken because we weren't removing the ".rm" before constructing the filename.