### PR TITLE
issue #135: stop logging entire HTML when go-get fails

### DIFF
--- a/pkg/clients/zips/http.go
+++ b/pkg/clients/zips/http.go
@@ -13,6 +13,8 @@ import (
 	"oss.indeed.com/go/modprox/pkg/upstream"
 )
 
+var maxLoggedBody = 500
+
 type httpClient struct {
 	client  *http.Client
 	options HTTPOptions
@@ -70,11 +72,20 @@ func (c *httpClient) Get(r *upstream.Request) (repository.Blob, error) {
 				response.StatusCode,
 			)
 		}
-		c.log.Errorf(
-			"bad response (%d), body: %s",
-			response.StatusCode,
-			string(bs),
-		)
+		body := string(bs)
+		if len(body) <= maxLoggedBody {
+			c.log.Errorf(
+				"bad response (%d), body: %s",
+				response.StatusCode,
+				body,
+			)
+		} else {
+			c.log.Errorf(
+				"bad response (%d), body: %s...",
+				response.StatusCode,
+				body[:maxLoggedBody],
+			)
+		}
 		return nil, errors.Wrapf(
 			err,
 			"unexpected response (%d)",

--- a/pkg/upstream/go-get.go
+++ b/pkg/upstream/go-get.go
@@ -8,10 +8,10 @@ import (
 	"regexp"
 	"strings"
 
-	"oss.indeed.com/go/modprox/pkg/loggy"
-
 	"github.com/pkg/errors"
 	"github.com/shoenig/httplus/responses"
+
+	"oss.indeed.com/go/modprox/pkg/loggy"
 )
 
 var maxLoggedBody = 500


### PR DESCRIPTION
There are a couple of places in the proxy where we log the entire response body when a request returns a 4xx.  This pull request truncates the logged body to the first 500 characters.